### PR TITLE
Add support for dpop_bound_access_tokens client registration metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Compiling this source and configuring an instance of the resulting plug-in withi
 
 ### System requirements and dependencies
 
-* PingFederate 9.3 or higher
+* PingFederate 11.3 or higher
+* PingFederate 9.3 support is available at [9.3](https://github.com/pingidentity/open-banking-plugin/tree/9.3) branch
 * PingFederate 9.2 support is available at [9.2](https://github.com/pingidentity/open-banking-plugin/tree/9.2) branch 
 * PingFederate 9.1 support is available at [9.1](https://github.com/pingidentity/open-banking-plugin/tree/9.1) branch 
 * PingFederate 9.0 support is available at [9.0](https://github.com/pingidentity/open-banking-plugin/tree/9.0) branch 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <pf.version>10.0.0.16</pf.version>
+        <pf.version>11.3.0.7</pf.version>
     </properties>
 
     <name>PingFederate Open Banking Software Assertion Validator</name>

--- a/src/main/java/com/pingidentity/clientregistration/ClaimTranslator.java
+++ b/src/main/java/com/pingidentity/clientregistration/ClaimTranslator.java
@@ -77,6 +77,11 @@ class ClaimTranslator
             case JWKS:
                 dynamicClient.setJwks(jwtClaims.getStringClaimValue(DynamicClientFields.JWKS.getName()));
                 break;
+            case DPOP_BOUND_ACCESS_TOKENS:
+                Boolean dpopBoundAccessTokensClaim = jwtClaims.getClaimValue(DynamicClientFields.DPOP_BOUND_ACCESS_TOKENS.getName(), Boolean.class);
+                boolean requireDpop = dpopBoundAccessTokensClaim != null ? dpopBoundAccessTokensClaim : false;
+                dynamicClient.setRequireDpop(requireDpop);
+                break;
             default:
                 processClaimsWithOverwrite(claimName, dynamicClient, jwtClaims, true, null);
                 break;

--- a/src/main/java/com/pingidentity/clientregistration/ClaimTranslator.java
+++ b/src/main/java/com/pingidentity/clientregistration/ClaimTranslator.java
@@ -77,11 +77,6 @@ class ClaimTranslator
             case JWKS:
                 dynamicClient.setJwks(jwtClaims.getStringClaimValue(DynamicClientFields.JWKS.getName()));
                 break;
-            case DPOP_BOUND_ACCESS_TOKENS:
-                Boolean dpopBoundAccessTokensClaim = jwtClaims.getClaimValue(DynamicClientFields.DPOP_BOUND_ACCESS_TOKENS.getName(), Boolean.class);
-                boolean requireDpop = dpopBoundAccessTokensClaim != null ? dpopBoundAccessTokensClaim : false;
-                dynamicClient.setRequireDpop(requireDpop);
-                break;
             default:
                 processClaimsWithOverwrite(claimName, dynamicClient, jwtClaims, true, null);
                 break;

--- a/src/main/java/com/pingidentity/clientregistration/ClaimTranslator.java
+++ b/src/main/java/com/pingidentity/clientregistration/ClaimTranslator.java
@@ -167,6 +167,15 @@ class ClaimTranslator
                 }
                 break;
 
+            case DPOP_BOUND_ACCESS_TOKENS:
+                if(isOverWriteValue(isOverwrite, otherJwtClaims, claimName))
+                {
+                    Boolean dpopBoundAccessTokensClaim = jwtClaimsForProcessing.getClaimValue(DynamicClientFields.DPOP_BOUND_ACCESS_TOKENS.getName(), Boolean.class);
+                    boolean requireDpop = dpopBoundAccessTokensClaim != null ? dpopBoundAccessTokensClaim : false;
+                    dynamicClient.setRequireDpop(requireDpop);
+                }
+                break;
+
             default:
                 // do nothing: we only consider the OAuth specific claims obtained from request JWT and PingFederate proprietary attributes.
                 // The remaining claims are treated as software or extended metadata.

--- a/src/main/java/com/pingidentity/clientregistration/OpenBankingPlugin.java
+++ b/src/main/java/com/pingidentity/clientregistration/OpenBankingPlugin.java
@@ -19,7 +19,6 @@ package com.pingidentity.clientregistration;
 
 import com.pingidentity.clientregistration.constants.Constants;
 import com.pingidentity.clientregistration.constants.DynamicClientSoftwareFields;
-import com.pingidentity.commonsvcs.api.Headers;
 import com.pingidentity.sdk.GuiConfigDescriptor;
 import com.pingidentity.sdk.PluginDescriptor;
 import com.pingidentity.sdk.oauth20.registration.*;
@@ -63,6 +62,8 @@ public class OpenBankingPlugin implements DynamicClientRegistrationPlugin
     private static final String VERSION = "1.0";
 
     private static final String MEDIA_TYPE_JWT = "application/jwt";
+
+    private static final String CONTENT_TYPE = "Content-Type";
 
     private String issuer;
     private JwksHandler jwksHandler;
@@ -165,7 +166,7 @@ public class OpenBankingPlugin implements DynamicClientRegistrationPlugin
     public void processPlugin(HttpServletRequest request, HttpServletResponse response, DynamicClient dynamicClient, Map<String, Object> inParameters)
             throws ClientRegistrationException
     {
-        String contentType = request.getHeader(Headers.CONTENT_TYPE);
+        String contentType = request.getHeader(CONTENT_TYPE);
         if (contentType != null && !contentType.toLowerCase().contains(MEDIA_TYPE_JWT))
         {
             throw new ClientRegistrationException(Response.Status.UNSUPPORTED_MEDIA_TYPE,

--- a/src/main/java/com/pingidentity/clientregistration/constants/Constants.java
+++ b/src/main/java/com/pingidentity/clientregistration/constants/Constants.java
@@ -55,7 +55,8 @@ public class Constants
                                                                                            DynamicClientFields.BACKCHANNEL_USER_CODE_PARAMETER,
                                                                                            DynamicClientFields.BACKCHANNEL_AUTHENTICATION_REQUEST_SIGNING_ALG,
                                                                                            DynamicClientFields.SUBJECT_TYPE,
-                                                                                           DynamicClientFields.SECTOR_IDENTIFIER_URI);
+                                                                                           DynamicClientFields.SECTOR_IDENTIFIER_URI,
+                                                                                           DynamicClientFields.DPOP_BOUND_ACCESS_TOKENS);
 
     public enum ApplicationType
     {

--- a/src/test/java/com/pingidentity/clientregistration/OpenBankingPluginTest.java
+++ b/src/test/java/com/pingidentity/clientregistration/OpenBankingPluginTest.java
@@ -317,4 +317,103 @@ public class OpenBankingPluginTest
     }
 
 
+    @Test
+    public void testSoftwareStatementDpopBoundAccessTokensEnabled()
+    {
+        String clientName = "testSoftwareStatementDpopBoundAccessTokensEnabled";
+        DynamicClient client = getDynamicClient();
+
+        JwtClaims requestClaims = populateClaims(clientName, REDIRECT_URIS_1, JWKS_1);
+        JwtClaims softwareStatementClaims = populateClaims(clientName, REDIRECT_URIS_1, JWKS_1);
+
+        // Set DPOP_BOUND_ACCESS_TOKENS claim to true in software statement
+        softwareStatementClaims.setClaim(DynamicClientFields.DPOP_BOUND_ACCESS_TOKENS.getName(), true);
+
+        try
+        {
+            claimTranslator.processClaims(client, softwareStatementClaims);
+            claimTranslator.processRequestJwtClaims(client, requestClaims, softwareStatementClaims);
+
+            Assert.assertTrue(client.isRequireDpop());
+        }
+        catch(ClientRegistrationException e)
+        {
+            Assert.fail("Unexpected");
+        }
+    }
+
+    @Test
+    public void testSoftwareStatementDpopBoundAccessTokensDisabled()
+    {
+        String clientName = "testSoftwareStatementDpopBoundAccessTokensDisabled";
+        DynamicClient client = getDynamicClient();
+
+        JwtClaims requestClaims = populateClaims(clientName, REDIRECT_URIS_1, JWKS_1);
+        JwtClaims softwareStatementClaims = populateClaims(clientName, REDIRECT_URIS_1, JWKS_1);
+
+        // Set DPOP_BOUND_ACCESS_TOKENS claim to false in software statement
+        softwareStatementClaims.setClaim(DynamicClientFields.DPOP_BOUND_ACCESS_TOKENS.getName(), false);
+
+        try
+        {
+            claimTranslator.processClaims(client, softwareStatementClaims);
+            claimTranslator.processRequestJwtClaims(client, requestClaims, softwareStatementClaims);
+
+            Assert.assertFalse(client.isRequireDpop());
+        }
+        catch(ClientRegistrationException e)
+        {
+            Assert.fail("Unexpected");
+        }
+    }
+
+    @Test
+    public void testSoftwareStatementDpopBoundAccessTokensNotSet()
+    {
+        String clientName = "testSoftwareStatementDpopBoundAccessTokensNotSet";
+        DynamicClient client = getDynamicClient();
+
+        JwtClaims requestClaims = populateClaims(clientName, REDIRECT_URIS_1, JWKS_1);
+        JwtClaims softwareStatementClaims = populateClaims(clientName, REDIRECT_URIS_1, JWKS_1);
+
+        // Do not set DPOP_BOUND_ACCESS_TOKENS claim in software statement
+
+        try
+        {
+            claimTranslator.processClaims(client, softwareStatementClaims);
+            claimTranslator.processRequestJwtClaims(client, requestClaims, softwareStatementClaims);
+
+            Assert.assertFalse(client.isRequireDpop());
+        }
+        catch(ClientRegistrationException e)
+        {
+            Assert.fail("Unexpected");
+        }
+    }
+
+    @Test
+    public void testRequestDpopBoundAccessTokensIgnored()
+    {
+        String clientName = "testRequestDpopBoundAccessTokensIgnored";
+        DynamicClient client = getDynamicClient();
+
+        JwtClaims requestClaims = populateClaims(clientName, REDIRECT_URIS_1, JWKS_1);
+        JwtClaims softwareStatementClaims = populateClaims(clientName, REDIRECT_URIS_1, JWKS_1);
+
+        // Set DPOP_BOUND_ACCESS_TOKENS claim to false in the request
+        requestClaims.setClaim(DynamicClientFields.DPOP_BOUND_ACCESS_TOKENS.getName(), true);
+
+        try
+        {
+            claimTranslator.processClaims(client, softwareStatementClaims);
+            claimTranslator.processRequestJwtClaims(client, requestClaims, softwareStatementClaims);
+
+            // DPOP_BOUND_ACCESS_TOKENS claim to false in the request is ignored
+            Assert.assertFalse(client.isRequireDpop());
+        }
+        catch(ClientRegistrationException e)
+        {
+            Assert.fail("Unexpected");
+        }
+    }
 }


### PR DESCRIPTION
Add support for `dpop_bound_access_tokens` client registration metadata per [draft-ietf-oauth-dpop](https://www.ietf.org/archive/id/draft-ietf-oauth-dpop-16.html#section-5.2).

Other changes include:
- Update PF Server SDK dependency version
- Remove reference to `com.pingidentity.commonsvcs.api.Headers` package which is not part of the PF Server SDK.